### PR TITLE
Improve error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ FalcorEndpoint.expressMiddleware = function(getDataSource) {
 };
 
 FalcorEndpoint.dataSourceRoute = function(getDataSource) {
-    return function(req, res) {
+    return function(req, res, next) {
         var obs;
         var dataSource = getDataSource(req, res);
         var context = requestToContext(req);
@@ -34,8 +34,10 @@ FalcorEndpoint.dataSourceRoute = function(getDataSource) {
         obs.subscribe(function(jsonGraphEnvelope) {
             res.status(200).send(JSON.stringify(jsonGraphEnvelope));
         }, function(err) {
+            if (err instanceof Error) {
+              return next(err);
+            }
             res.status(500).send(err);
         });
     };
 };
-


### PR DESCRIPTION
`res.send()`ing an Error object just returns `{}`. Better to pass errors like this on to Express's default error handling. This makes debugging Routers much nicer!

Note: `npm run lint` and `npm test` are failing in this commit, but it doesn't appear to be a result of what I added.