### PR TITLE
Json header

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "eslint": "^0.21.0",
-    "falcor-router": "0.2.4",
+    "falcor-router": "0.2.9",
     "gulp": "^3.9.0",
     "gulp-eslint": "^0.15.0",
     "gulp-mocha": "^2.1.3",

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ FalcorEndpoint.dataSourceRoute = function(getDataSource) {
         }
 
         obs.subscribe(function(jsonGraphEnvelope) {
-            res.status(200).send(JSON.stringify(jsonGraphEnvelope));
+            res.status(200).json(jsonGraphEnvelope);
         }, function(err) {
             if (err instanceof Error) {
               return next(err);

--- a/test/dataSourceRoute.js
+++ b/test/dataSourceRoute.js
@@ -77,6 +77,7 @@ describe('dataSourceRoute', function () {
       expect(fakeRes.json.calledOnce).to.equal(true);
       // Check that the res.send was called with a jsonGraph object
       var sentValue = fakeRes.json.args[0][0];
+      expect(typeof(sentValue)).to.equal('object');
       expect(!!sentValue.jsonGraph).to.equal(true);
 
       done();

--- a/test/dataSourceRoute.js
+++ b/test/dataSourceRoute.js
@@ -18,7 +18,7 @@ describe('dataSourceRoute', function () {
       // Stubbed response object
       var fakeRes = {
         status: sinon.stub().returnsThis(),
-        send: sinon.stub().returnsThis()
+        json: sinon.stub().returnsThis()
       };
 
       // Set up basic router and immediately invoke the returned funciton
@@ -35,9 +35,10 @@ describe('dataSourceRoute', function () {
       expect(fakeRes.status.calledOnce).to.equal(true);
       expect(fakeRes.status.args).to.deep.equal([[200]]);
 
-      expect(fakeRes.send.calledOnce).to.equal(true);
+      expect(fakeRes.json.calledOnce).to.equal(true);
       // Check that the res.send was called with a jsonGraph object
-      var sentValue = JSON.parse(fakeRes.send.args);
+      var sentValue = fakeRes.json.args[0][0];
+      expect(typeof(sentValue)).to.equal('object');
       expect(!!sentValue.jsonGraph).to.equal(true);
 
       done();
@@ -56,7 +57,7 @@ describe('dataSourceRoute', function () {
       // Stubbed response object
       var fakeRes = {
         status: sinon.stub().returnsThis(),
-        send: sinon.stub().returnsThis()
+        json: sinon.stub().returnsThis()
       };
 
       // Set up basic router and immediately invoke the returned funciton
@@ -73,9 +74,9 @@ describe('dataSourceRoute', function () {
       expect(fakeRes.status.calledOnce).to.equal(true);
       expect(fakeRes.status.args).to.deep.equal([[200]]);
 
-      expect(fakeRes.send.calledOnce).to.equal(true);
+      expect(fakeRes.json.calledOnce).to.equal(true);
       // Check that the res.send was called with a jsonGraph object
-      var sentValue = JSON.parse(fakeRes.send.args);
+      var sentValue = fakeRes.json.args[0][0];
       expect(!!sentValue.jsonGraph).to.equal(true);
 
       done();


### PR DESCRIPTION
Using `res.json` in order to obtain proper JSON header in response. Tests also updated to reflect change.

For #25